### PR TITLE
Add conda installation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -29,6 +29,12 @@ Installation
 tasklogger is available on `pip`. Install by running the following in a terminal::
 
     pip install --user tasklogger
+    
+Alternatively, tasklogger can be installed using [Conda](https://conda.io/docs/) (most easily obtained via the [Miniconda Python distribution](https://conda.io/miniconda.html)):
+
+
+    conda install -c conda-forge tasklogger
+
 
 Usage example
 -------------


### PR DESCRIPTION
Hi,

tasklogger is now available for conda via [conda-forge](https://anaconda.org/conda-forge/tasklogger). I added the installation information

Bérénice